### PR TITLE
Enable parent page scrolling from embedded map boundaries

### DIFF
--- a/article.html
+++ b/article.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Article Page</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 200vh;
+      font-family: sans-serif;
+    }
+    iframe {
+      width: 100%;
+      height: 100vh;
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <h1>Sample Article</h1>
+  <iframe src="index.html" id="map-frame"></iframe>
+  <script>
+    window.addEventListener('message', function(event) {
+      if (event.data && event.data.type === 'iframe-scroll') {
+        const delta = event.data.delta || 0;
+        requestAnimationFrame(() => {
+          window.scrollBy(0, delta);
+        });
+      }
+    });
+  </script>
+  <p>More content...</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -239,12 +239,48 @@
 
     window.addEventListener('resize', function () {
       scroller.resize();
-      
+
       // Update map settings on resize
       const newSettings = getMapSettings();
       map.setView(newSettings.center, newSettings.zoom);
       map.fitBounds(tileBounds, { padding: newSettings.padding });
     });
+
+    function handleBoundaryScroll(deltaY) {
+      const atTop = window.scrollY <= 0;
+      const atBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight;
+      if ((atTop && deltaY < 0) || (atBottom && deltaY > 0)) {
+        parent.postMessage({ type: 'iframe-scroll', delta: deltaY }, '*');
+        return true;
+      }
+      return false;
+    }
+
+    document.addEventListener('wheel', function (event) {
+      if (handleBoundaryScroll(event.deltaY)) {
+        event.preventDefault();
+      }
+    }, { passive: false });
+
+    let lastTouchY = null;
+
+    document.addEventListener('touchstart', function (event) {
+      if (event.touches.length === 1) {
+        lastTouchY = event.touches[0].clientY;
+      }
+    }, { passive: true });
+
+    document.addEventListener('touchmove', function (event) {
+      if (event.touches.length !== 1 || lastTouchY === null) return;
+
+      const currentY = event.touches[0].clientY;
+      const deltaY = lastTouchY - currentY;
+      lastTouchY = currentY;
+
+      if (handleBoundaryScroll(deltaY)) {
+        event.preventDefault();
+      }
+    }, { passive: false });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Detect overscroll at top/bottom of embedded map and forward wheel/touch delta to parent with `postMessage`.
- Add sample article page that listens for iframe scroll messages and scrolls the host page with `requestAnimationFrame`.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890df9c6a3083238764a22687298b87