### PR TITLE
Forward boundary scroll to parent page

### DIFF
--- a/article.html
+++ b/article.html
@@ -19,16 +19,6 @@
 <body>
   <h1>Sample Article</h1>
   <iframe src="index.html" id="map-frame"></iframe>
-  <script>
-    window.addEventListener('message', function(event) {
-      if (event.data && event.data.type === 'iframe-scroll') {
-        const delta = event.data.delta || 0;
-        requestAnimationFrame(() => {
-          window.scrollBy(0, delta);
-        });
-      }
-    });
-  </script>
   <p>More content...</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -250,7 +250,13 @@
       const atTop = window.scrollY <= 0;
       const atBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight;
       if ((atTop && deltaY < 0) || (atBottom && deltaY > 0)) {
-        parent.postMessage({ type: 'iframe-scroll', delta: deltaY }, '*');
+        if (parent && parent !== window) {
+          try {
+            parent.scrollBy(0, deltaY);
+          } catch (e) {
+            // Ignore cross-origin access errors
+          }
+        }
         return true;
       }
       return false;


### PR DESCRIPTION
## Summary
- When the iframe hits top or bottom, forward the wheel/touch delta to the parent page using `parent.scrollBy`
- Drop parent-page messaging demo so embedding page needs no script changes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689003e5c5548323b0384eb045ae4195