### PR TITLE
Forward final-step scroll to parent

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,5 +164,10 @@
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://unpkg.com/scrollama"></script>
   <script src="script.js"></script>
+  <script>
+    function sendParentScroll(direction) {
+      window.parent.postMessage({type: 'iframeScroll', direction}, '*');
+    }
+  </script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -60,26 +60,88 @@ const layer1932 = L.tileLayer('tiles/1932/{z}/{x}/{y}.png', {
 
 const scroller = scrollama();
 
+const TOTAL_STEPS = 8;
+let touchStartY = null;
+let listenersActive = false;
+
 function handleStepEnter(response) {
   document.querySelectorAll('.step').forEach(s => s.classList.remove('is-active'));
   response.element.classList.add('is-active');
+
+  const stepNum = parseInt(response.element.dataset.step, 10);
+  if (stepNum === TOTAL_STEPS) {
+    addExitListeners();
+  } else {
+    removeExitListeners();
+  }
 }
 
 function handleStepExit(response) {
   response.element.classList.remove('is-active');
+
+  const stepNum = parseInt(response.element.dataset.step, 10);
+  if (stepNum === TOTAL_STEPS) {
+    removeExitListeners();
+  }
 }
 
 function handleStepProgress(response) {
   const step = parseInt(response.element.dataset.step);
   const progress = response.progress;
-  const totalSteps = 8;
-  const overallProgress = (step - 1 + progress) / totalSteps;
+  const overallProgress = (step - 1 + progress) / TOTAL_STEPS;
 
   // Smoother easing function for opacity transition
   const easedProgress = 1 - Math.pow(overallProgress, 0.6);
   const opacity = Math.max(0, Math.min(1, easedProgress));
 
   layer1932.setOpacity(opacity);
+}
+
+function addExitListeners() {
+  if (listenersActive) return;
+  document.addEventListener('wheel', handleWheel, { passive: false });
+  document.addEventListener('touchstart', handleTouchStart, { passive: false });
+  document.addEventListener('touchmove', handleTouchMove, { passive: false });
+  document.addEventListener('touchend', handleTouchEnd, { passive: false });
+  listenersActive = true;
+}
+
+function removeExitListeners() {
+  if (!listenersActive) return;
+  document.removeEventListener('wheel', handleWheel, { passive: false });
+  document.removeEventListener('touchstart', handleTouchStart, { passive: false });
+  document.removeEventListener('touchmove', handleTouchMove, { passive: false });
+  document.removeEventListener('touchend', handleTouchEnd, { passive: false });
+  listenersActive = false;
+  touchStartY = null;
+}
+
+function handleWheel(e) {
+  if (e.deltaY > 0) {
+    e.preventDefault();
+    sendParentScroll('down');
+    removeExitListeners();
+  }
+}
+
+function handleTouchStart(e) {
+  if (e.touches.length === 1) {
+    touchStartY = e.touches[0].clientY;
+  }
+}
+
+function handleTouchMove(e) {
+  if (touchStartY === null) return;
+  const currentY = e.touches[0].clientY;
+  if (touchStartY - currentY > 0) {
+    e.preventDefault();
+    sendParentScroll('down');
+    removeExitListeners();
+  }
+}
+
+function handleTouchEnd() {
+  touchStartY = null;
 }
 
 scroller


### PR DESCRIPTION
## Summary
- Add `sendParentScroll` helper for messaging parent window
- Detect final step and attach wheel/touch listeners to capture downward scroll
- Forward downward scroll past last step to parent and clean up listeners

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68922dd6396483239adb6cd9e3a0dbb7